### PR TITLE
feat: whitelist `.config` dirname

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -153,8 +153,10 @@ impl ZellijPlugin for State {
 }
 
 fn is_hidden(path: &Path) -> bool {
+    const WHITELIST: [&str; 1] = [".config"];
+
     path.file_name()
         .and_then(|s| s.to_str())
-        .map(|s| s.starts_with('.'))
+        .map(|s| s.starts_with('.') && !WHITELIST.contains(&s))
         .unwrap_or(false)
 }


### PR DESCRIPTION
This PR closes #6.

This pull request includes a small change to the `src/main.rs` file. The change introduces a whitelist for hidden files, allowing certain hidden files to be visible.

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR156-R160): Added a `WHITELIST` constant to allow `.config` files to be visible in the `is_hidden` function.