### PR TITLE
Make it possible to use custom layout by folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ tmux {
 arguments:
 
 - root_dirs: string of paths separated by a semicolon, default is `""`
-- session_layout: the layout to use for new sessions, please prepend the layout name with a `:` if you want to use a built-in layout ex: `:compact`, default is `:default`.
+- session_layout: the layout to use for new sessions, please prepend the layout name with a `:` if you want to use a built-in layout ex: `:compact`, default is `:default`. If there is a `layout.kdl` on the target folder it will be used instead.
 
 **IMPORTANT:** I highly recommend setting cwd to `/`. due to the way plugins interact with the filesystem the root_dirs **must** be absolute paths and **must** be descendants of the cwd.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,13 @@ impl State {
     fn switch_session_with_cwd(&self, dir: &Path) -> Result<(), String> {
         let session_name = dir.file_name().unwrap().to_str().unwrap();
         let cwd = dir.to_path_buf();
-        let layout = self.config.layout.clone();
+        let layout_path = dir.to_str().unwrap().to_string() + "/layout.kdl";
+        let host_layout_path = ROOT.to_string() + layout_path.as_str();
+        let layout = if PathBuf::from(host_layout_path.clone()).exists() {
+            LayoutInfo::File(host_layout_path)
+        } else {
+            self.config.layout.clone()
+        };
         // Switch session will panic if the session is the current session
         if session_name != self.current_session {
             switch_session_with_layout(Some(session_name), layout, Some(cwd));

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,10 +36,11 @@ impl State {
     fn switch_session_with_cwd(&self, dir: &Path) -> Result<(), String> {
         let session_name = dir.file_name().unwrap().to_str().unwrap();
         let cwd = dir.to_path_buf();
-        let layout_path = dir.to_str().unwrap().to_string() + "/layout.kdl";
-        let host_layout_path = ROOT.to_string() + layout_path.as_str();
-        let layout = if PathBuf::from(host_layout_path.clone()).exists() {
-            LayoutInfo::File(host_layout_path)
+        let host_layout_path = PathBuf::from(ROOT)
+            .join(dir.strip_prefix("/").unwrap())
+            .join("layout.kdl");
+        let layout = if host_layout_path.exists() {
+            LayoutInfo::File(host_layout_path.to_str().unwrap().into())
         } else {
             self.config.layout.clone()
         };


### PR DESCRIPTION
This should close https://github.com/laperlej/zellij-sessionizer/issues/9.

This adds a way to create a session using local layouts, instead of only using default templates, which is not ideal, because some projects demands a more custom layout.