### PR TITLE
feature: Use CTRL+w to delete the previous word

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
     name: Build distributables
     runs-on: ubuntu-latest
     steps:
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
+      - name: Install wasm32-wasip1
+        run: rustup target add wasm32-wasip1
       - uses: actions/checkout@v3
       - name: Build
         run: cargo build --release
@@ -27,4 +27,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ./target/wasm32-wasi/release/zellij-sessionizer.wasm
+          files: ./target/wasm32-wasip1/release/zellij-sessionizer.wasm

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ clean:
 	@pkill watchexec
 
 deploy:
-	cargo build --target wasm32-wasi --release
-	@cp $(shell pwd)/target/wasm32-wasi/release/zellij-sessionizer.wasm ~/.config/zellij/plugins
+	cargo build --target wasm32-wasip1 --release
+	@cp $(shell pwd)/target/wasm32-wasip1/release/zellij-sessionizer.wasm ~/.config/zellij/plugins

--- a/plugin-dev-workspace.kdl
+++ b/plugin-dev-workspace.kdl
@@ -7,12 +7,12 @@ layout {
         pane {
             pane stacked=true {
                 pane size="10%" command="bash" name="COMPILE AND RELOAD PLUGIN" {
-                    // args "-c" "cargo build && zellij action start-or-reload-plugin file:target/wasm32-wasi/debug/zellij-sessionizer.wasm"
+                    // args "-c" "cargo build && zellij action start-or-reload-plugin file:target/wasm32-wasip1/debug/zellij-sessionizer.wasm"
                     // if you have "watchexec" installed, you can comment the above line and uncomment the below one to build + reload the plugin on fs changes
-                    args "-c" "watchexec 'cargo build && zellij action start-or-reload-plugin file:target/wasm32-wasi/debug/zellij-sessionizer.wasm'"
+                    args "-c" "watchexec 'cargo build && zellij action start-or-reload-plugin file:target/wasm32-wasip1/debug/zellij-sessionizer.wasm'"
                 }
                 pane expanded=true {
-                    plugin location="file:target/wasm32-wasi/debug/zellij-sessionizer.wasm"
+                    plugin location="file:target/wasm32-wasip1/debug/zellij-sessionizer.wasm"
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,14 @@ impl ZellijPlugin for State {
                             .set_search_term(self.textinput.get_text().as_str());
                     }
                     KeyWithModifier {
+                        bare_key: BareKey::Char('w'),
+                        key_modifiers,
+                    } if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+                        self.textinput.handle_delete_word();
+                        self.dirlist
+                            .set_search_term(self.textinput.get_text().as_str());
+                    }
+                    KeyWithModifier {
                         bare_key: BareKey::Char(c),
                         key_modifiers: _,
                     } => {

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -31,13 +31,24 @@ impl TextInput {
     pub fn reset(&mut self) {
         self.text.clear();
     }
-    
+
     pub fn get_text(&self) -> String {
         self.text.iter().collect::<String>()
     }
 
     pub fn handle_backspace(&mut self) {
             self.text.pop();
+    }
+
+    pub fn handle_delete_word(&mut self) {
+        let mut i = self.text.len();
+        while i > 0 && self.text[i - 1].is_whitespace() {
+            i -= 1;
+        }
+        while i > 0 && !self.text[i - 1].is_whitespace() {
+            i -= 1;
+        }
+        self.text.truncate(i);
     }
 
     pub fn handle_char(&mut self, c: char) {


### PR DESCRIPTION
Thank you for this plugin! I use it every day but often wish I could CTRL+w to remove the previous word (and trailing spaces) like is common in shells and editors - I imagine others way expect it to work this way too.

The implementation for `delete_word` could be cleaner with an iterator chain but this is more readable.

I also had some issues with CI and building because wasm32-wasi has been renamed to wasm32-wasip1 so I updated that too where necessary.

You can try v0.4.4 on my fork to test the functionality. I'm using it now and it works well for me.