### PR TITLE
feature: More keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ The main difference with the built-in filepicker is that the search is done over
 
 ## Usage
 
-- up/down arrow: select previous/next folder
+- up/down arrow and shift+tab/tab: select previous/next folder
 - enter: create session based on selected folder
 - other characters will populate a search bar that will apply fuzzy find.
+
+Additionally, there are a few Vim-like keybindings:
+
+- ctrl+p/ctrl+n: select previous/next folder
+- ctrl+u/ctrl+d: move selection half a page up/down the folder list
 
 ## Installation
 

--- a/src/dirlist.rs
+++ b/src/dirlist.rs
@@ -45,6 +45,19 @@ impl DirList {
         }
     }
 
+    pub fn handle_half_page_up(&mut self, rows: usize) {
+        let half_page = rows / 2;
+        self.cursor = self.cursor.saturating_sub(half_page);
+    }
+
+    pub fn handle_half_page_down(&mut self, rows: usize) {
+        let half_page = rows / 2;
+        self.cursor = self
+            .cursor
+            .saturating_add(half_page)
+            .min(self.filtered_dirs.len().saturating_sub(1));
+    }
+
     pub fn get_selected(&self) -> Option<String> {
         if self.cursor < self.filtered_dirs.len() {
             Some(self.filtered_dirs[self.cursor].clone())

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ struct State {
 
     config: Config,
     debug: String,
+    rows: usize,
 }
 
 register_plugin!(State);
@@ -155,6 +156,18 @@ impl ZellijPlugin for State {
                         self.dirlist.handle_down();
                     }
                     KeyWithModifier {
+                        bare_key: BareKey::Char('u'),
+                        key_modifiers,
+                    } if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+                        self.dirlist.handle_half_page_up(self.rows);
+                    }
+                    KeyWithModifier {
+                        bare_key: BareKey::Char('d'),
+                        key_modifiers,
+                    } if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+                        self.dirlist.handle_half_page_down(self.rows);
+                    }
+                    KeyWithModifier {
                         bare_key: BareKey::Enter,
                         key_modifiers: _,
                     } => {
@@ -196,8 +209,9 @@ impl ZellijPlugin for State {
     }
 
     fn render(&mut self, rows: usize, cols: usize) {
+        self.rows = rows.saturating_sub(4);
         println!();
-        self.dirlist.render(rows.saturating_sub(4), cols);
+        self.dirlist.render(self.rows, cols);
         println!();
         self.textinput.render(rows, cols);
         println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,10 +126,11 @@ impl ZellijPlugin for State {
             Event::Key(key) => {
                 should_render = true;
                 match key {
-                    KeyWithModifier {
-                        bare_key: BareKey::Esc,
-                        ..
-                    } => close_self(),
+                    k if matches_key(&k, BareKey::Char('d'), Some(&[KeyModifier::Ctrl]))
+                        || matches_key(&k, BareKey::Esc, None) =>
+                    {
+                        close_self()
+                    }
 
                     k if matches_key(&k, BareKey::Up, None)
                         || matches_key(&k, BareKey::Tab, Some(&[KeyModifier::Shift]))
@@ -145,28 +146,22 @@ impl ZellijPlugin for State {
                         self.dirlist.handle_down();
                     }
 
-                    k if matches_key(&k, BareKey::Char('u'), Some(&[KeyModifier::Ctrl])) => {
+                    k if matches_key(&k, BareKey::PageUp, None) => {
                         self.dirlist.handle_half_page_up(self.rows);
                     }
 
-                    k if matches_key(&k, BareKey::Char('d'), Some(&[KeyModifier::Ctrl])) => {
+                    k if matches_key(&k, BareKey::PageDown, None) => {
                         self.dirlist.handle_half_page_down(self.rows);
                     }
 
-                    KeyWithModifier {
-                        bare_key: BareKey::Enter,
-                        ..
-                    } => {
+                    k if matches_key(&k, BareKey::Enter, None) => {
                         if let Some(selected) = self.dirlist.get_selected() {
                             let _ = self.switch_session_with_cwd(Path::new(&selected));
                             close_self();
                         }
                     }
 
-                    KeyWithModifier {
-                        bare_key: BareKey::Backspace,
-                        ..
-                    } => {
+                    k if matches_key(&k, BareKey::Backspace, None) => {
                         self.textinput.handle_backspace();
                         self.dirlist
                             .set_search_term(self.textinput.get_text().as_str());

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,16 +121,26 @@ impl ZellijPlugin for State {
                         close_self();
                     }
                     KeyWithModifier {
-                        bare_key: BareKey::Down,
-                        key_modifiers: _,
-                    } => {
-                        self.dirlist.handle_down();
+                        bare_key: BareKey::Tab,
+                        key_modifiers,
+                    } if key.has_modifiers(&[KeyModifier::Shift]) => {
+                        self.dirlist.handle_up();
                     }
                     KeyWithModifier {
                         bare_key: BareKey::Up,
                         key_modifiers: _,
                     } => {
                         self.dirlist.handle_up();
+                    }
+                    KeyWithModifier {
+                        bare_key: BareKey::Down,
+                        key_modifiers: _,
+                    }
+                    | KeyWithModifier {
+                        bare_key: BareKey::Tab,
+                        key_modifiers: _,
+                    } => {
+                        self.dirlist.handle_down();
                     }
                     KeyWithModifier {
                         bare_key: BareKey::Enter,

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,6 +143,18 @@ impl ZellijPlugin for State {
                         self.dirlist.handle_down();
                     }
                     KeyWithModifier {
+                        bare_key: BareKey::Char('p'),
+                        key_modifiers,
+                    } if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+                        self.dirlist.handle_up();
+                    }
+                    KeyWithModifier {
+                        bare_key: BareKey::Char('n'),
+                        key_modifiers,
+                    } if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+                        self.dirlist.handle_down();
+                    }
+                    KeyWithModifier {
                         bare_key: BareKey::Enter,
                         key_modifiers: _,
                     } => {


### PR DESCRIPTION
This partially solves #11. 

I disagree about adding a whole modal editing setup for a small plugin but, I think this is a good compromise without affecting the default bindings or requiring an additional config option. 

If you'd prefer to gate some/all of these new bindings behind an option, I can do that :]

I added `rows` to `State` so that we could do accurate half pages regardless of the rendered size.