### PR TITLE
Feature: support for 'individual dirs' outside of 'root dirs'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ tmux {
             move_to_focused_tab true
             cwd "/"
             root_dirs "/home/laperlej/projects;/home/laperlej/workspaces"
+            individual_dirs "/home/laperlej/.dotfiles;/etc/nginx"
             session_layout "myCustomLayout"
         }; SwitchToMode "Locked";
     }
@@ -49,7 +50,8 @@ tmux {
 
 arguments:
 
-- root_dirs: string of paths separated by a semicolon, default is `""`
+- root_dirs: string of paths separated by a semicolon, default is `""`. Each path is scanned for subdirectories (1 level deep) which are then presented as selectable sessions.
+- individual_dirs: string of paths separated by a semicolon, default is `""`. Each path is added directly as a selectable session, without scanning for subdirectories. This is useful for including specific directories that aren't grouped under a common parent.
 - session_layout: the layout to use for new sessions, please prepend the layout name with a `:` if you want to use a built-in layout ex: `:compact`, default is `:default`. If there is a `layout.kdl` on the target folder it will be used instead.
 
 **IMPORTANT:** I highly recommend setting cwd to `/`. due to the way plugins interact with the filesystem the root_dirs **must** be absolute paths and **must** be descendants of the cwd.

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,14 +7,16 @@ use crate::ROOT;
 
 #[derive(Debug)]
 pub struct Config {
-    pub dirs: Vec<PathBuf>,
+    pub root_dirs: Vec<PathBuf>,
+    pub individual_dirs: Vec<PathBuf>,
     pub layout: LayoutInfo,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            dirs: vec![PathBuf::from(ROOT)],
+            root_dirs: vec![PathBuf::from(ROOT)],
+            individual_dirs: vec![],
             layout: LayoutInfo::BuiltIn("default".to_string())
         }
     }
@@ -36,18 +38,22 @@ fn parse_dirs(dirs: &str) -> Vec<PathBuf> {
 
 impl From<BTreeMap<String, String>> for Config {
     fn from(config: BTreeMap<String, String>) -> Self {
-        let dirs: Vec<PathBuf> = match config.get("root_dirs") {
+        let root_dirs: Vec<PathBuf> = match config.get("root_dirs") {
             Some(root_dirs) => parse_dirs(root_dirs),
             _ => vec![PathBuf::from(ROOT)]
+        };
+        let individual_dirs: Vec<PathBuf> = match config.get("individual_dirs") {
+            Some(individual_dirs) => parse_dirs(individual_dirs),
+            _ => vec![]
         };
         let layout = match config.get("session_layout") {
             Some(layout) => parse_layout(layout),
             _ => LayoutInfo::BuiltIn("default".to_string())
         };
         Self {
-            dirs,
+            root_dirs,
+            individual_dirs,
             layout
         }
     }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ impl ZellijPlugin for State {
         self.dirlist.reset();
         self.textinput.reset();
         let host = PathBuf::from(ROOT);
-        for dir in &self.config.dirs {
+        for dir in &self.config.root_dirs {
             let relative_path = match dir.strip_prefix(self.cwd.as_path()) {
                 Ok(p) => p,
                 Err(_) => continue,
@@ -92,6 +92,11 @@ impl ZellijPlugin for State {
             let host_path = host.join(relative_path);
             scan_host_folder(&host_path);
         }
+        let individual_dirs: Vec<String> = self.config.individual_dirs
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+        self.dirlist.update_dirs(individual_dirs);
     }
 
     fn update(&mut self, event: Event) -> bool {


### PR DESCRIPTION
in my case it's useful for some folders within `~/.config` - I don't want the whole of `~/.config` to appear in the list, just some folders of my choosing