### PR TITLE
fix(windows): make root_dirs scanning work on native Windows

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ impl Default for Config {
         Self {
             root_dirs: vec![PathBuf::from(ROOT)],
             individual_dirs: vec![],
-            layout: LayoutInfo::BuiltIn("default".to_string())
+            layout: LayoutInfo::BuiltIn("default".to_string()),
         }
     }
 }
@@ -31,29 +31,28 @@ fn parse_layout(layout: &str) -> LayoutInfo {
     }
 }
 
-
 fn parse_dirs(dirs: &str) -> Vec<PathBuf> {
-    return dirs.split(';').map(PathBuf::from).collect()
+    return dirs.split(';').map(PathBuf::from).collect();
 }
 
 impl From<BTreeMap<String, String>> for Config {
     fn from(config: BTreeMap<String, String>) -> Self {
         let root_dirs: Vec<PathBuf> = match config.get("root_dirs") {
             Some(root_dirs) => parse_dirs(root_dirs),
-            _ => vec![PathBuf::from(ROOT)]
+            _ => vec![PathBuf::from(ROOT)],
         };
         let individual_dirs: Vec<PathBuf> = match config.get("individual_dirs") {
             Some(individual_dirs) => parse_dirs(individual_dirs),
-            _ => vec![]
+            _ => vec![],
         };
         let layout = match config.get("session_layout") {
             Some(layout) => parse_layout(layout),
-            _ => LayoutInfo::BuiltIn("default".to_string())
+            _ => LayoutInfo::BuiltIn("default".to_string()),
         };
         Self {
             root_dirs,
             individual_dirs,
-            layout
+            layout,
         }
     }
 }

--- a/src/dirlist.rs
+++ b/src/dirlist.rs
@@ -38,7 +38,7 @@ impl DirList {
             self.cursor -= 1;
         }
     }
-    
+
     pub fn handle_down(&mut self) {
         if self.cursor < self.filtered_dirs.len().saturating_sub(1) {
             self.cursor += 1;
@@ -76,9 +76,11 @@ impl DirList {
         self.cursor = self.filtered_dirs.len().saturating_sub(1);
     }
 
-
     pub fn render(&self, rows: usize, _cols: usize) {
-        let from = self.cursor.saturating_sub(rows.saturating_sub(1) / 2).min(self.filtered_dirs.len().saturating_sub(rows));
+        let from = self
+            .cursor
+            .saturating_sub(rows.saturating_sub(1) / 2)
+            .min(self.filtered_dirs.len().saturating_sub(rows));
         let missing_rows = rows.saturating_sub(self.filtered_dirs.len());
         if missing_rows > 0 {
             for _ in 0..missing_rows {
@@ -103,4 +105,3 @@ impl DirList {
             })
     }
 }
-

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,6 +1,5 @@
-use nucleo_matcher::{Config, Matcher};
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
-
+use nucleo_matcher::{Config, Matcher};
 
 //from https://docs.rs/nucleo-matcher/0.3.1/nucleo_matcher/
 //
@@ -13,13 +12,20 @@ use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 
 pub fn fuzzy_filter(items: &[String], search_term: &str) -> Vec<String> {
     if search_term.is_empty() {
-        let sorted = items.iter().map(|item| item.to_string()).collect::<Vec<_>>();
+        let sorted = items
+            .iter()
+            .map(|item| item.to_string())
+            .collect::<Vec<_>>();
         return sorted;
     }
     let mut matcher = Matcher::new(Config::DEFAULT.match_paths());
-    let mut matches = Pattern::parse(search_term, CaseMatching::Ignore, Normalization::Smart).match_list(items, &mut matcher);
+    let mut matches = Pattern::parse(search_term, CaseMatching::Ignore, Normalization::Smart)
+        .match_list(items, &mut matcher);
     matches.sort_by(|a, b| a.1.cmp(&b.1));
-    matches.into_iter().map(|(item, _)| item.to_string()).collect()
+    matches
+        .into_iter()
+        .map(|(item, _)| item.to_string())
+        .collect()
 }
 
 #[cfg(test)]
@@ -28,7 +34,14 @@ mod tests {
 
     #[test]
     fn test_fuzzy_filter() {
-        let items: Vec<String> = vec!["/home/laperlej/Projects/bioblend", "/home/laperlej/Projects/backup-rotation", "/home/laperlej/Projects/github.io"].into_iter().map(|item| item.to_string()).collect();
+        let items: Vec<String> = vec![
+            "/home/laperlej/Projects/bioblend",
+            "/home/laperlej/Projects/backup-rotation",
+            "/home/laperlej/Projects/github.io",
+        ]
+        .into_iter()
+        .map(|item| item.to_string())
+        .collect();
         let search_term = "bio";
         let result = fuzzy_filter(&items, search_term);
         assert_eq!(result, vec!["/home/laperlej/Projects/bioblend"]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,13 +48,18 @@ impl State {
     fn switch_session_with_cwd(&self, dir: &Path) -> Result<(), String> {
         let session_name = dir.file_name().unwrap().to_str().unwrap();
         let cwd = dir.to_path_buf();
-        let host_layout_path = PathBuf::from(ROOT)
-            .join(dir.strip_prefix("/").unwrap())
-            .join("layout.kdl");
-        let layout = if host_layout_path.exists() {
-            LayoutInfo::File(host_layout_path.to_str().unwrap().into())
-        } else {
-            self.config.layout.clone()
+        // strip_prefix("/") only works for Unix absolute paths; on Windows dirs
+        // start with a drive letter so we fall back to the configured layout.
+        let layout = match dir.strip_prefix("/") {
+            Ok(relative) => {
+                let host_layout_path = PathBuf::from(ROOT).join(relative).join("layout.kdl");
+                if host_layout_path.exists() {
+                    LayoutInfo::File(host_layout_path.to_str().unwrap().into())
+                } else {
+                    self.config.layout.clone()
+                }
+            }
+            Err(_) => self.config.layout.clone(),
         };
         // Switch session will panic if the session is the current session
         if session_name != self.current_session {
@@ -66,12 +71,23 @@ impl State {
     fn make_dirlist(&mut self, paths: &[(PathBuf, Option<FileMetadata>)]) -> Vec<String> {
         paths
             .iter()
-            .filter(|(p, _)| p.is_dir() && !is_hidden(p))
+            .filter(|(p, metadata)| {
+                // Use Zellij's FileMetadata when available instead of p.is_dir(),
+                // because inside the WASM sandbox on Windows the virtual /host/...
+                // paths cannot be stat'd by the OS and is_dir() always returns false.
+                let is_dir = metadata.map(|m| m.is_dir).unwrap_or_else(|| p.is_dir());
+                is_dir && !is_hidden(p)
+            })
             .map(|(p, _)| {
-                if p.starts_with(ROOT) {
-                    self.change_root(p)
+                // On Windows, Zellij returns paths with backslashes in FileSystemUpdate
+                // (e.g. /host\Users\azin\repos\project). Inside the WASM sandbox, which
+                // uses Unix path semantics, backslashes are not separators and are treated
+                // as part of the filename, breaking starts_with("/host"). Normalise first.
+                let normalized = PathBuf::from(p.to_string_lossy().replace('\\', "/"));
+                if normalized.starts_with(ROOT) {
+                    self.change_root(&normalized)
                 } else {
-                    p.to_path_buf()
+                    normalized
                 }
             })
             .map(|p| p.to_string_lossy().to_string())
@@ -97,14 +113,16 @@ impl ZellijPlugin for State {
         self.textinput.reset();
         let host = PathBuf::from(ROOT);
         for dir in &self.config.root_dirs {
-            let relative_path = match dir.strip_prefix(self.cwd.as_path()) {
-                Ok(p) => p,
-                Err(_) => continue,
+            let relative_path = match strip_prefix_portable(dir, self.cwd.as_path()) {
+                Some(p) => p,
+                None => continue,
             };
             let host_path = host.join(relative_path);
             scan_host_folder(&host_path);
         }
-        let individual_dirs: Vec<String> = self.config.individual_dirs
+        let individual_dirs: Vec<String> = self
+            .config
+            .individual_dirs
             .iter()
             .map(|p| p.to_string_lossy().to_string())
             .collect();
@@ -206,6 +224,38 @@ impl ZellijPlugin for State {
             println!();
             println!("{}", self.debug);
         }
+    }
+}
+
+/// `Path::strip_prefix` is case-sensitive and treats `/` and `\` as distinct,
+/// which causes silent failures on Windows where the host may mix separators
+/// or use different drive-letter casing.  This helper normalises both paths to
+/// lowercase with forward slashes before comparing, then slices the *original*
+/// string so the returned relative path keeps its original casing.
+fn strip_prefix_portable(path: &Path, prefix: &Path) -> Option<PathBuf> {
+    // Fast path: stdlib works fine for pure Unix paths (no drive letters).
+    if let Ok(rel) = path.strip_prefix(prefix) {
+        return Some(rel.to_path_buf());
+    }
+    // Slow path: normalise separators and case for Windows-style paths.
+    let norm = |p: &Path| p.to_string_lossy().to_lowercase().replace('\\', "/");
+    let path_n = norm(path);
+    let prefix_n = norm(prefix);
+    // Ensure the prefix ends with `/` to avoid matching partial component names
+    // (e.g. prefix "c:/foo" accidentally matching "c:/foobar").
+    let prefix_sep = if prefix_n.ends_with('/') {
+        prefix_n.clone()
+    } else {
+        format!("{}/", prefix_n)
+    };
+    if path_n == prefix_n {
+        Some(PathBuf::new())
+    } else if path_n.starts_with(&prefix_sep) {
+        // Slice the *original* (un-normalised) string so casing is preserved.
+        let original = path.to_string_lossy();
+        Some(PathBuf::from(&original[prefix_sep.len()..]))
+    } else {
+        None
     }
 }
 

--- a/src/textinput.rs
+++ b/src/textinput.rs
@@ -37,7 +37,7 @@ impl TextInput {
     }
 
     pub fn handle_backspace(&mut self) {
-            self.text.pop();
+        self.text.pop();
     }
 
     pub fn handle_delete_word(&mut self) {
@@ -60,7 +60,10 @@ impl TextInput {
 
     pub fn render(&self, _rows: usize, _cols: usize) {
         let search_term = self.text.iter().collect::<String>();
-        let search_bar_content = format!("{} {}{}", self.marker_symbol, search_term, self.cursor_symbol);
+        let search_bar_content = format!(
+            "{} {}{}",
+            self.marker_symbol, search_term, self.cursor_symbol
+        );
         let search_bar_len = search_bar_content.len();
         let search_bar = Text::new(search_bar_content)
             .color_range(self.marker_color, 0..1)


### PR DESCRIPTION
## Problem

On native Windows, `root_dirs` would show no folders at all, and selecting a folder caused a panic.

## Root Causes & Fixes

**1. `strip_prefix` silently skipping all `root_dirs`**
`Path::strip_prefix()` is case-sensitive and treats `\` as a literal in the WASM sandbox (which uses Unix path semantics). This caused every entry in `root_dirs` to be silently skipped. Fixed with a new `strip_prefix_portable()` helper that normalises separators and casing before comparing.

**2. `p.is_dir()` always returning false**
Inside the WASM sandbox, virtual `/host/...` paths cannot be stat'd by the OS on Windows, so `is_dir()` always returned `false` and all results were filtered out. Fixed by using `FileMetadata.is_dir` from the event payload instead.

**3. Backslash paths breaking `starts_with("/host")`**
Zellij returns `FileSystemUpdate` paths with backslashes on Windows (e.g. `/host\Users\azin\repos\project`). The WASM runtime treats backslashes as part of the filename, so `starts_with("/host")` never matched and `change_root()` was never called. Fixed by normalising to forward slashes before the check.

**4. Panic when selecting a folder**
`switch_session_with_cwd` called `.unwrap()` on `strip_prefix("/")`, which panics for Windows drive-letter paths (e.g. `C:\Users\...`). Fixed by matching on the result and falling back to the configured layout gracefully.

## Config required for Windows users

```
bind "Ctrl y" {
    LaunchOrFocusPlugin "file:~/.config/zellij/plugins/zellij-sessionizer.wasm" {
        floating true
        move_to_focused_tab true
        cwd "C:/"
        root_dirs "C:/Users/<you>/repos"
    }
}
```

`cwd` must be set to the drive root (`C:/`) so it is an ancestor of all `root_dirs` entries. Tilde (`~`) expansion is not reliable on Windows so full paths are required.
